### PR TITLE
Make sure to include trajectory_builder.lua for 3d.

### DIFF
--- a/cartographer_ros/configuration_files/turtlebot_3d.lua
+++ b/cartographer_ros/configuration_files/turtlebot_3d.lua
@@ -13,6 +13,7 @@
 -- limitations under the License.
 
 include "map_builder.lua"
+include "trajectory_builder.lua"
 
 options = {
   map_builder = MAP_BUILDER,


### PR DESCRIPTION
No CI, as this doesn't affect the build, only runtime.

connects to ros2/ros2#342