### PR TITLE
Use standard urdfdom-headers rosdep key.

### DIFF
--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -35,7 +35,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>tf2_eigen</build_depend>
-  <build_depend>urdfdom_headers</build_depend>
+  <build_depend>urdfdom-headers</build_depend>
 
   <depend>cartographer</depend>
   <depend>cartographer_ros_msgs</depend>


### PR DESCRIPTION
We're shadowing this key for r2b2 since upstream is out of date but we should
use the rosdep key so we can eventually target upstream.

https://github.com/ros2/robot_model/pull/1