### PR TITLE
Revert "Use standard urdfdom-headers rosdep key."

### DIFF
--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -35,7 +35,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>tf2_eigen</build_depend>
-  <build_depend>urdfdom-headers</build_depend>
+  <build_depend>urdfdom_headers</build_depend>
 
   <depend>cartographer</depend>
   <depend>cartographer_ros_msgs</depend>


### PR DESCRIPTION
Reverts ros2/cartographer_ros#6 same issue as https://github.com/ros2/urdfdom/pull/3

cc @clalancette this broke your build http://ci.ros2.org/job/ci_turtlebot-demo_linux/48/