### PR TITLE
Rename dependency key for urdfdom-headers.

### DIFF
--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -35,7 +35,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>tf2_eigen</build_depend>
-  <build_depend>urdfdom_headers</build_depend>
+  <build_depend>urdfdom-headers</build_depend>
 
   <depend>cartographer</depend>
   <depend>cartographer_ros_msgs</depend>


### PR DESCRIPTION
We're shadowing this key for r2b2 since upstream is out of date but we should
use the rosdep key so we can eventually target upstream.

https://github.com/ros2/robot_model/pull/1

This is the second attempt to do so after the first failed due to the
urdfdom_headers package not being renamed for source builds. That is
being resolved by placing a package.xml with the updated name in the
source tree rather than in a release patch.