### PR TITLE
tf2_ros::Buffer requires a clock

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -85,9 +85,10 @@ namespace carto = ::cartographer;
 
 using carto::transform::Rigid3d;
 
-Node::Node(const NodeOptions& node_options, tf2_ros::Buffer* const tf_buffer)
+Node::Node(const NodeOptions& node_options, rclcpp::Node::SharedPtr node_handle, tf2_ros::Buffer* const tf_buffer)
     : node_options_(node_options),
-      map_builder_bridge_(node_options_, tf_buffer) {
+      map_builder_bridge_(node_options_, tf_buffer),
+      node_handle_(node_handle) {
   carto::common::MutexLocker lock(&mutex_);
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
 
@@ -95,7 +96,6 @@ Node::Node(const NodeOptions& node_options, tf2_ros::Buffer* const tf_buffer)
   custom_qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   custom_qos_profile.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
 
-  node_handle_ = rclcpp::Node::make_shared("cartographer_node");
   submap_list_publisher_ =
       node_handle_->create_publisher<::cartographer_ros_msgs::msg::SubmapList>(
           kSubmapListTopic, custom_qos_profile);

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -48,7 +48,7 @@ namespace cartographer_ros {
 // Wires up ROS topics to SLAM.
 class Node {
  public:
-  Node(const NodeOptions& node_options, tf2_ros::Buffer* tf_buffer);
+  Node(const NodeOptions& node_options, rclcpp::Node::SharedPtr node_handle, tf2_ros::Buffer* tf_buffer);
   ~Node();
 
   Node(const Node&) = delete;

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -42,15 +42,17 @@ namespace cartographer_ros {
 namespace {
 
 void Run() {
+  auto node_handle = rclcpp::Node::make_shared("cartographer_node");
   constexpr double kTfBufferCacheTimeInSeconds = 1e6;
-  tf2_ros::Buffer tf_buffer{::tf2::durationFromSec(kTfBufferCacheTimeInSeconds)};
+  tf2_ros::Buffer tf_buffer(
+    node_handle->get_clock(), ::tf2::durationFromSec(kTfBufferCacheTimeInSeconds));
   tf2_ros::TransformListener tf(tf_buffer);
   NodeOptions node_options;
   TrajectoryOptions trajectory_options;
   std::tie(node_options, trajectory_options) =
       LoadOptions(FLAGS_configuration_directory, FLAGS_configuration_basename);
 
-  Node node(node_options, &tf_buffer);
+  Node node(node_options, node_handle, &tf_buffer);
   if (!FLAGS_map_filename.empty()) {
     node.LoadMap(FLAGS_map_filename);
   }


### PR DESCRIPTION
ros2/geometry2#67 changed `tf2_ros::Buffer()` to require a clock. This fixes the broken turtlebot nightly.

connects to ros2/navigation#33