### PR TITLE
Fix argument intialization to allow node to take in params

### DIFF
--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -80,6 +80,9 @@ void Run() {
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
+  // It is important to initialize rclcpp first or copy argv,
+  // because the google commands eat the arguments
+  ::rclcpp::init(argc, argv);
   google::InitGoogleLogging(argv[0]);
   google::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -88,7 +91,6 @@ int main(int argc, char** argv) {
   CHECK(!FLAGS_configuration_basename.empty())
       << "-configuration_basename is missing.";
 
-  ::rclcpp::init(argc, argv);
 
   cartographer_ros::ScopedRosLogSink ros_log_sink;
   cartographer_ros::Run();


### PR DESCRIPTION
The google initializers were modifying the commandline arguments somehow so that params couldn't be passed in via command line.

My launchfile looks like
```
        Node(
            package='cartographer_ros',
            node_executable='cartographer_node',
            node_name='cartographer_node',
            output='screen',
            parameters=[{'use_sim_time': 'true'}],
            arguments=[
                '-configuration_directory', LaunchConfiguration('cartographer_config_dir'),
                '-configuration_basename', LaunchConfiguration('configuration_basename'),
                '--undefok=r,params-file,ros-args']),
```

But the `use_sim_time` param was not being parsed, so the TF broadcaster was publishing with wall time, which didn't match up with my Gazebo simulation.