### PR TITLE
Strip ROS args before passing to GFlags

### DIFF
--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -80,24 +80,11 @@ void Run() {
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
-  // Strip ROS specific arguments
-  std::vector<std::string> non_ros_args = rclcpp::remove_ros_arguments(argc, argv);
-
-  // Create argc and argv equivalents
-  int non_ros_argc = non_ros_args.size();
-  char ** non_ros_argv = new char*[non_ros_argc];
-  for (size_t i = 0; i < non_ros_args.size(); ++i) {
-    non_ros_argv[i] = new char[non_ros_args.at(i).size()];
-    strcpy(non_ros_argv[i], non_ros_args.at(i).c_str());
-  }
-
-  google::InitGoogleLogging(non_ros_argv[0]);
-  google::ParseCommandLineFlags(&non_ros_argc, &non_ros_argv, false);
-
-  for (size_t i = 0; i < non_ros_args.size(); ++i) {
-    delete [] non_ros_argv[i];
-  }
-  delete [] non_ros_argv;
+  // Keep going if an unknown flag is encountered
+  // https://github.com/gflags/gflags/issues/148#issuecomment-318826625
+  google::AllowCommandLineReparsing();
+  google::InitGoogleLogging(argv[0]);
+  google::ParseCommandLineFlags(&argc, &argv, false);
 
   CHECK(!FLAGS_configuration_directory.empty())
       << "-configuration_directory is missing.";

--- a/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
@@ -183,8 +183,24 @@ class OccupancyGridNode : public rclcpp::Node
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  // Strip ROS specific arguments
+  std::vector<std::string> non_ros_args = rclcpp::remove_ros_arguments(argc, argv);
+
+  // Create argc and argv equivalents
+  int non_ros_argc = non_ros_args.size();
+  char ** non_ros_argv = new char*[non_ros_argc];
+  for (size_t i = 0; i < non_ros_args.size(); ++i) {
+    non_ros_argv[i] = new char[non_ros_args.at(i).size()];
+    strcpy(non_ros_argv[i], non_ros_args.at(i).c_str());
+  }
+
+  google::InitGoogleLogging(non_ros_argv[0]);
+  google::ParseCommandLineFlags(&non_ros_argc, &non_ros_argv, false);
+
+  for (size_t i = 0; i < non_ros_args.size(); ++i) {
+    delete [] non_ros_argv[i];
+  }
+  delete [] non_ros_argv;
 
   ::rclcpp::init(argc, argv);
 

--- a/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
@@ -183,24 +183,11 @@ class OccupancyGridNode : public rclcpp::Node
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
-  // Strip ROS specific arguments
-  std::vector<std::string> non_ros_args = rclcpp::remove_ros_arguments(argc, argv);
-
-  // Create argc and argv equivalents
-  int non_ros_argc = non_ros_args.size();
-  char ** non_ros_argv = new char*[non_ros_argc];
-  for (size_t i = 0; i < non_ros_args.size(); ++i) {
-    non_ros_argv[i] = new char[non_ros_args.at(i).size()];
-    strcpy(non_ros_argv[i], non_ros_args.at(i).c_str());
-  }
-
-  google::InitGoogleLogging(non_ros_argv[0]);
-  google::ParseCommandLineFlags(&non_ros_argc, &non_ros_argv, false);
-
-  for (size_t i = 0; i < non_ros_args.size(); ++i) {
-    delete [] non_ros_argv[i];
-  }
-  delete [] non_ros_argv;
+  // Keep going if an unknown flag is encountered
+  // https://github.com/gflags/gflags/issues/148#issuecomment-318826625
+  google::AllowCommandLineReparsing();
+  google::InitGoogleLogging(argv[0]);
+  google::ParseCommandLineFlags(&argc, &argv, false);
 
   ::rclcpp::init(argc, argv);
 


### PR DESCRIPTION
GFlags complains it doesn't know about the flags `ros-args` and `r` when launching these nodes with remap rules in eloquent. This is because in eloquent ros specific arguments should be wrapped with `--ros-args` and remap rules prefixed with `-r`. This strips the ros specific arguments out so GFlags doesn't see them.