### PR TITLE
Init rclcpp first

### DIFF
--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -80,6 +80,9 @@ void Run() {
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
+  // Init rclcpp first because gflags reorders command line flags in argv
+  ::rclcpp::init(argc, argv);
+
   // Keep going if an unknown flag is encountered
   // https://github.com/gflags/gflags/issues/148#issuecomment-318826625
   google::AllowCommandLineReparsing();
@@ -90,8 +93,6 @@ int main(int argc, char** argv) {
       << "-configuration_directory is missing.";
   CHECK(!FLAGS_configuration_basename.empty())
       << "-configuration_basename is missing.";
-
-  ::rclcpp::init(argc, argv);
 
   cartographer_ros::ScopedRosLogSink ros_log_sink;
   cartographer_ros::Run();

--- a/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
@@ -183,13 +183,14 @@ class OccupancyGridNode : public rclcpp::Node
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
+  // Init rclcpp first because gflags reorders command line flags in argv
+  ::rclcpp::init(argc, argv);
+
   // Keep going if an unknown flag is encountered
   // https://github.com/gflags/gflags/issues/148#issuecomment-318826625
   google::AllowCommandLineReparsing();
   google::InitGoogleLogging(argv[0]);
   google::ParseCommandLineFlags(&argc, &argv, false);
-
-  ::rclcpp::init(argc, argv);
 
   auto node = std::make_shared<cartographer_ros::OccupancyGridNode>(FLAGS_resolution, FLAGS_publish_period_sec);
 


### PR DESCRIPTION
Basically a redo of #39, which I had undone in #40 thinking it wasn't necessary anymore.
Even if gflags is told not to remove arguments from argv, it still reorders them in argv. This breaks ROS 2 argument parsing of multiple remap rules because the flags become separated from their arguments.