### PR TITLE
Minor updates to the cartographer_ros build for Rolling

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -46,15 +46,11 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_msgs REQUIRED)
-# find_package(urdf REQUIRED)
 find_package(visualization_msgs REQUIRED)
-
-include(FindPkgConfig)
 
 find_package(LuaGoogle REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(Eigen3 REQUIRED)
-# find_package(Boost REQUIRED COMPONENTS system iostreams)
 find_package(urdfdom_headers REQUIRED)
 
 if(DEFINED urdfdom_headers_VERSION)
@@ -66,19 +62,6 @@ endif()
 include_directories(
   include
   "."
-  ${cartographer_INCLUDE_DIRS}
-  ${cartographer_ros_msgs_INCLUDE_DIRS}
-  ${geometry_msgs_INCLUDE_DIRS}
-  ${nav_msgs_INCLUDE_DIRS}
-  ${pcl_conversions_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-  ${sensor_msgs_INCLUDE_DIRS}
-  ${std_msgs_INCLUDE_DIRS}
-  ${tf2_INCLUDE_DIRS}
-  ${tf2_msgs_INCLUDE_DIRS}
-  ${tf2_ros_INCLUDE_DIRS}
-  ${tf2_eigen_INCLUDE_DIRS}
-  ${visualization_msgs_INCLUDE_DIRS}
 )
 
 # # Override Catkin's GTest configuration to use GMock.
@@ -104,8 +87,22 @@ set(ALL_SRCS
   "cartographer_ros/time_conversion.cc"
   "cartographer_ros/trajectory_options.cc"
   "cartographer_ros/submap.cc"
-  )
+)
 add_library(${PROJECT_NAME} ${ALL_SRCS})
+ament_target_dependencies(${PROJECT_NAME} PUBLIC
+  cartographer_ros_msgs
+  geometry_msgs
+  nav_msgs
+  pcl_conversions
+  rclcpp
+  sensor_msgs
+  std_msgs
+  tf2
+  tf2_eigen
+  tf2_msgs
+  tf2_ros
+  visualization_msgs
+)
 add_subdirectory("cartographer_ros")
 
 target_link_libraries(${PROJECT_NAME} PUBLIC cartographer)
@@ -128,11 +125,6 @@ endforeach()
 # Eigen
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   "${EIGEN3_INCLUDE_DIR}")
-
-# # Boost
-# target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-#   "${Boost_INCLUDE_DIRS}")
-# target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
 
 # YAML
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${YAMLCPP_INCLUDE_DIRS})

--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -17,17 +17,7 @@ add_executable(cartographer_node
 target_include_directories(cartographer_node SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
 target_link_libraries(cartographer_node ${PROJECT_NAME})
 ament_target_dependencies(cartographer_node
-  "cartographer_ros_msgs"
-  "geometry_msgs"
-  "nav_msgs"
-  "pcl_conversions"
-  "rclcpp"
-  "std_msgs"
-  "sensor_msgs"
-  "tf2"
-  "tf2_msgs"
-  "tf2_ros"
-  "visualization_msgs"
+  rclcpp
 )
 
 add_executable(occupancy_grid_node
@@ -35,10 +25,9 @@ add_executable(occupancy_grid_node
 target_include_directories(occupancy_grid_node SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
 target_link_libraries(occupancy_grid_node ${PROJECT_NAME})
 ament_target_dependencies(occupancy_grid_node
-  "cartographer_ros_msgs"
-  "nav_msgs"
-  "rclcpp"
-  "std_msgs"
+  cartographer_ros_msgs
+  nav_msgs
+  rclcpp
 )
 
 install(TARGETS

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -21,7 +21,6 @@
 #include "gflags/gflags.h"
 
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/transform_listener.h>
 
 DEFINE_string(configuration_directory, "",
               "First directory in which configuration files are searched, "

--- a/cartographer_ros/cartographer_ros/ros_log_sink.cc
+++ b/cartographer_ros/cartographer_ros/ros_log_sink.cc
@@ -50,19 +50,19 @@ void ScopedRosLogSink::send(const ::google::LogSeverity severity,
       severity, GetBasename(filename), line, tm_time, message, message_len);
   switch (severity) {
     case ::google::GLOG_INFO:
-      RCLCPP_INFO(rclcpp::get_logger("cartographer_ros"), message_string);
+      RCLCPP_INFO(rclcpp::get_logger("cartographer_ros"), "%s", message_string.c_str());
       break;
 
     case ::google::GLOG_WARNING:
-      RCLCPP_WARN(rclcpp::get_logger("cartographer_ros"), message_string);
+      RCLCPP_WARN(rclcpp::get_logger("cartographer_ros"), "%s", message_string.c_str());
       break;
 
     case ::google::GLOG_ERROR:
-      RCLCPP_ERROR(rclcpp::get_logger("cartographer_ros"), message_string);
+      RCLCPP_ERROR(rclcpp::get_logger("cartographer_ros"), "%s", message_string.c_str());
       break;
 
     case ::google::GLOG_FATAL:
-      RCLCPP_FATAL(rclcpp::get_logger("cartographer_ros"), message_string);
+      RCLCPP_FATAL(rclcpp::get_logger("cartographer_ros"), "%s", message_string.c_str());
       will_die_ = true;
       break;
   }


### PR DESCRIPTION
The main goal of this PR is to fix the build of cartographer_ros on Rolling.  In particular, Rolling no longer allows using `std::string` for the RCLCPP_ macros, so fix that here.  This is also backwards compatible to Foxy and Dashing.

While we were in here, I noticed a bunch of non-optimal setup for the CMakeLists.txt.  Clean up some of this just to make it more ament-like.