### PR TITLE
add pbstream_to_ros_map_node

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -87,6 +87,7 @@ set(ALL_SRCS
   "cartographer_ros/time_conversion.cc"
   "cartographer_ros/trajectory_options.cc"
   "cartographer_ros/submap.cc"
+  "cartographer_ros/ros_map.cc"
 )
 add_library(${PROJECT_NAME} ${ALL_SRCS})
 ament_target_dependencies(${PROJECT_NAME} PUBLIC

--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -30,9 +30,15 @@ ament_target_dependencies(occupancy_grid_node
   rclcpp
 )
 
+add_executable(pbstream_to_ros_map_node
+  pbstream_to_ros_map_main.cc)
+target_include_directories(pbstream_to_ros_map_node SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
+target_link_libraries(pbstream_to_ros_map_node ${PROJECT_NAME})
+
 install(TARGETS
   cartographer_node
   occupancy_grid_node
+  pbstream_to_ros_map_node
   DESTINATION lib/${PROJECT_NAME})
 
 # google_binary(cartographer_assets_writer


### PR DESCRIPTION
#53 
Add a conversion node from pbstream to ros map

Now the ros map can be saved in a way similar to ROS1
```
ros2 service call /finish_trajectory cartographer_ros_msgs/srv/FinishTrajectory trajectory_id:\ 0
ros2 service call /write_state cartographer_ros_msgs/srv/WriteState filename:\ test.pbstream
```
Finally, convert the pbstream to ros map through pbstream_to_ros_map_node
```
ros2 run cartographer_ros pbstream_to_ros_map_node -pbstream_filename test.pbstream -map_filestem test_ros_map
```
which will generate the `test_ros_map.pgm` and `test_ros_map.yaml` in current folder