### PR TITLE
Port assets_writer to ROS2

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -40,15 +40,15 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(urdf REQUIRED)
 find_package(visualization_msgs REQUIRED)
-find_package(rosbag2_cpp)
-find_package(urdf)
 
 find_package(LuaGoogle REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
@@ -78,21 +78,21 @@ include_directories(
 # list(REMOVE_ITEM ALL_SRCS ${ALL_EXECUTABLES})
 
 set(ALL_SRCS
+  "cartographer_ros/assets_writer.cc"
   "cartographer_ros/map_builder_bridge.cc"
   "cartographer_ros/msg_conversion.cc"
   "cartographer_ros/node.cc"
   "cartographer_ros/node_constants.cc"
   "cartographer_ros/node_options.cc"
   "cartographer_ros/ros_log_sink.cc"
+  "cartographer_ros/ros_map.cc"
+  "cartographer_ros/ros_map_writing_points_processor.cc"
   "cartographer_ros/sensor_bridge.cc"
+  "cartographer_ros/split_string.cc"
+  "cartographer_ros/submap.cc"
   "cartographer_ros/tf_bridge.cc"
   "cartographer_ros/time_conversion.cc"
   "cartographer_ros/trajectory_options.cc"
-  "cartographer_ros/submap.cc"
-  "cartographer_ros/ros_map.cc"
-  "cartographer_ros/assets_writer.cc"
-  "cartographer_ros/split_string.cc"
-  "cartographer_ros/ros_map_writing_points_processor.cc"
   "cartographer_ros/urdf_reader.cc"
 )
 add_library(${PROJECT_NAME} ${ALL_SRCS})
@@ -102,15 +102,15 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC
   nav_msgs
   pcl_conversions
   rclcpp
+  rosbag2_cpp
   sensor_msgs
   std_msgs
   tf2
   tf2_eigen
   tf2_msgs
   tf2_ros
-  visualization_msgs
-  rosbag2_cpp
   urdf
+  visualization_msgs
 )
 add_subdirectory("cartographer_ros")
 

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -47,6 +47,8 @@ find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
+find_package(rosbag2_cpp)
+find_package(urdf)
 
 find_package(LuaGoogle REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
@@ -88,6 +90,10 @@ set(ALL_SRCS
   "cartographer_ros/trajectory_options.cc"
   "cartographer_ros/submap.cc"
   "cartographer_ros/ros_map.cc"
+  "cartographer_ros/assets_writer.cc"
+  "cartographer_ros/split_string.cc"
+  "cartographer_ros/ros_map_writing_points_processor.cc"
+  "cartographer_ros/urdf_reader.cc"
 )
 add_library(${PROJECT_NAME} ${ALL_SRCS})
 ament_target_dependencies(${PROJECT_NAME} PUBLIC
@@ -103,6 +109,8 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC
   tf2_msgs
   tf2_ros
   visualization_msgs
+  rosbag2_cpp
+  urdf
 )
 add_subdirectory("cartographer_ros")
 

--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -35,10 +35,16 @@ add_executable(pbstream_to_ros_map_node
 target_include_directories(pbstream_to_ros_map_node SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
 target_link_libraries(pbstream_to_ros_map_node ${PROJECT_NAME})
 
+add_executable(assets_writer_node
+  assets_writer_main.cc)
+target_include_directories(assets_writer_node SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
+target_link_libraries(assets_writer_node ${PROJECT_NAME})
+
 install(TARGETS
   cartographer_node
   occupancy_grid_node
   pbstream_to_ros_map_node
+  assets_writer_node
   DESTINATION lib/${PROJECT_NAME})
 
 # google_binary(cartographer_assets_writer

--- a/cartographer_ros/cartographer_ros/assets_writer.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer.cc
@@ -45,8 +45,8 @@
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
 #include "rosbag2_cpp/serialization_format_converter_factory.hpp"
-#include <rclcpp/serialization.hpp>
-#include "tf2_eigen/tf2_eigen.h"
+#include "rclcpp/serialization.hpp"
+#include "tf2_eigen/tf2_eigen.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
 #include "urdf/model.h"
@@ -196,13 +196,12 @@ void AssetsWriter::Run(const std::string& configuration_directory,
       if (!urdf_filename.empty()) {
         ReadStaticTransformsFromUrdf(urdf_filename, tf_buffer);
       }
-
       const carto::transform::TransformInterpolationBuffer
           transform_interpolation_buffer(trajectory_proto);
       rosbag2_cpp::Reader bag_reader(
         std::make_unique<rosbag2_cpp::readers::SequentialReader>()
       );
-      rosbag2_cpp::StorageOptions storage_options {
+      rosbag2_storage::StorageOptions storage_options {
           bag_filename,
           "sqlite3",
       };

--- a/cartographer_ros/cartographer_ros/urdf_reader.cc
+++ b/cartographer_ros/cartographer_ros/urdf_reader.cc
@@ -25,7 +25,7 @@
 namespace cartographer_ros {
 
 std::vector<geometry_msgs::msg::TransformStamped> ReadStaticTransformsFromUrdf(
-    const std::string& urdf_filename, std::shared_ptr<tf2_ros::Buffer> const tf_buffer) {
+    const std::string& urdf_filename, tf2_ros::Buffer* const tf_buffer) {
   urdf::Model model;
   CHECK(model.initFile(urdf_filename));
 #if URDFDOM_HEADERS_HAS_SHARED_PTR_DEFS

--- a/cartographer_ros/cartographer_ros/urdf_reader.cc
+++ b/cartographer_ros/cartographer_ros/urdf_reader.cc
@@ -24,8 +24,8 @@
 
 namespace cartographer_ros {
 
-std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
-    const std::string& urdf_filename, tf2_ros::Buffer* const tf_buffer) {
+std::vector<geometry_msgs::msg::TransformStamped> ReadStaticTransformsFromUrdf(
+    const std::string& urdf_filename, std::shared_ptr<tf2_ros::Buffer> const tf_buffer) {
   urdf::Model model;
   CHECK(model.initFile(urdf_filename));
 #if URDFDOM_HEADERS_HAS_SHARED_PTR_DEFS
@@ -34,7 +34,7 @@ std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
   std::vector<boost::shared_ptr<urdf::Link> > links;
 #endif
   model.getLinks(links);
-  std::vector<geometry_msgs::TransformStamped> transforms;
+  std::vector<geometry_msgs::msg::TransformStamped> transforms;
   for (const auto& link : links) {
     if (!link->getParent() || link->parent_joint->type != urdf::Joint::FIXED) {
       continue;
@@ -42,7 +42,7 @@ std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
 
     const urdf::Pose& pose =
         link->parent_joint->parent_to_joint_origin_transform;
-    geometry_msgs::TransformStamped transform;
+    geometry_msgs::msg::TransformStamped transform;
     transform.transform =
         ToGeometryMsgTransform(cartographer::transform::Rigid3d(
             Eigen::Vector3d(pose.position.x, pose.position.y, pose.position.z),

--- a/cartographer_ros/cartographer_ros/urdf_reader.h
+++ b/cartographer_ros/cartographer_ros/urdf_reader.h
@@ -24,8 +24,8 @@
 
 namespace cartographer_ros {
 
-std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
-    const std::string& urdf_filename, tf2_ros::Buffer* tf_buffer);
+std::vector<geometry_msgs::msg::TransformStamped> ReadStaticTransformsFromUrdf(
+    const std::string& urdf_filename, std::shared_ptr<tf2_ros::Buffer> tf_buffer);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/urdf_reader.h
+++ b/cartographer_ros/cartographer_ros/urdf_reader.h
@@ -25,7 +25,7 @@
 namespace cartographer_ros {
 
 std::vector<geometry_msgs::msg::TransformStamped> ReadStaticTransformsFromUrdf(
-    const std::string& urdf_filename, std::shared_ptr<tf2_ros::Buffer> tf_buffer);
+    const std::string& urdf_filename, tf2_ros::Buffer* tf_buffer);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -76,7 +76,8 @@
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <!-- <depend>urdf</depend> -->
+  <depend>urdf</depend>
+  <depend>rosbag2_cpp</depend>
   <depend>visualization_msgs</depend>
   <depend>tf2_msgs</depend>
   <depend>yaml-cpp</depend>


### PR DESCRIPTION
#47 
Add assets_writer_node which can be called by
```
ros2 run cartographer_ros assets_writer_node \
-configuration_directory=xxx \
-configuration_basename=xxx.lua\
-bag_filenames=xxx\
-pose_graph_filename=xxx.pbstream\
-output_file_prefix=xxx\
-urdf_filename=xxx
``` 
where urdf_filename is optional

This code is tested in foxy, so I submit it to ros2 branch