### PR TITLE
fix cmake to prevent multiple definitions

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -59,20 +59,13 @@ include_directories(
 # Library
 add_library(${PROJECT_NAME}
   src/assets_writer.cpp
-  src/assets_writer_main.cpp
   src/map_builder_bridge.cpp
   src/msg_conversion.cpp
   src/node_constants.cpp
   src/node.cpp
-  src/node_main.cpp
   src/node_options.cpp
-  src/occupancy_grid_node_main.cpp
   src/offline_node.cpp
-  src/offline_node_main.cpp
-  src/pbstream_map_publisher_main.cpp
-  src/pbstream_to_ros_map_main.cpp
   src/playable_bag.cpp
-  src/rosbag_validate_main.cpp
   src/ros_log_sink.cpp
   src/ros_map.cpp
   src/ros_map_writing_points_processor.cpp


### PR DESCRIPTION
I've seen double definition errors for a couple of symbols and I think the reason is that the `_main.cpp` files should not be part of the library (they are used to create the executables later in the CMake file).