### PR TITLE
Fix warnings when compiling for newer Ubuntu releases

### DIFF
--- a/cartographer_ros/src/occupancy_grid_node_main.cpp
+++ b/cartographer_ros/src/occupancy_grid_node_main.cpp
@@ -37,6 +37,7 @@
 #include "gflags/gflags.h"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
 
 DEFINE_double(resolution, 0.05,
               "Resolution of a grid cell in the published occupancy grid.");
@@ -93,7 +94,11 @@ Node::Node(const double resolution, const double publish_period_sec)
   callback_group_executor_->add_callback_group(callback_group_, this->get_node_base_interface());
   client_ = this->create_client<cartographer_ros_msgs::srv::SubmapQuery>(
         kSubmapQueryServiceName,
+#if RCLCPP_VERSION_GTE(17, 0, 0)
+        rclcpp::ServicesQoS(),
+#else
         rmw_qos_profile_services_default,
+#endif
         callback_group_
         );
 

--- a/cartographer_rviz/include/cartographer_rviz/ogre_slice.h
+++ b/cartographer_rviz/include/cartographer_rviz/ogre_slice.h
@@ -25,7 +25,7 @@
 #include "OgreSceneManager.h"
 #include "OgreSceneNode.h"
 #include "OgreTexture.h"
-#include "OgreVector3.h"
+#include "Ogre.h"
 #include "cartographer/io/submap_painter.h"
 #include "cartographer/mapping/id.h"
 

--- a/cartographer_rviz/src/submaps_display.cpp
+++ b/cartographer_rviz/src/submaps_display.cpp
@@ -26,6 +26,7 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <pluginlib/class_list_macros.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
 #include <rviz_common/display_context.hpp>
 #include <rviz_common/frame_manager_iface.hpp>
 #include <rviz_common/properties/bool_property.hpp>
@@ -67,7 +68,11 @@ SubmapsDisplay::SubmapsDisplay() : rclcpp::Node("submaps_display") {
   callback_group_executor_->add_callback_group(callback_group_, this->get_node_base_interface());
   client_ = this->create_client<::cartographer_ros_msgs::srv::SubmapQuery>(
         kDefaultSubmapQueryServiceName,
+#if RCLCPP_VERSION_GTE(17, 0, 0)
+        rclcpp::ServicesQoS(),
+#else
         rmw_qos_profile_services_default,
+#endif
         callback_group_
         );
   trajectories_category_ = new ::rviz_common::properties::Property(
@@ -112,7 +117,11 @@ void SubmapsDisplay::Reset() { reset(); }
 void SubmapsDisplay::CreateClient() {
   client_ = this->create_client<::cartographer_ros_msgs::srv::SubmapQuery>(
       submap_query_service_property_->getStdString(),
+#if RCLCPP_VERSION_GTE(17, 0, 0)
+      rclcpp::ServicesQoS(),
+#else
       rmw_qos_profile_services_default,
+#endif
       callback_group_
       );
 }


### PR DESCRIPTION
This set of small changes makes it so that cartographer_ros compiles mostly warning-free on both Ubuntu 22.04 and Ubuntu 24.04, and also compiles against both older ROS 2 (Humble and Iron), along with newer ROS 2 (Rolling).