### PR TITLE
Deprecating tf2 C Headers

### DIFF
--- a/cartographer_ros/src/rosbag_validate_main.cpp
+++ b/cartographer_ros/src/rosbag_validate_main.cpp
@@ -37,7 +37,7 @@
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
 #include "urdf/model.h"
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 DEFINE_string(bag_filename, "", "Bag to process.");
 DEFINE_bool(dump_timing, false,


### PR DESCRIPTION
Related to this [pull request](https://github.com/ros2/geometry2/pull/720) in `geometry2` in which we deprecated the `.h` style headers in favor of `.hpp`.

Edit: I should mention this is meant to be a preemptive PR for if/when the related pull request gets approved. I'm also working on a backport so there won't be distribution issues