### PR TITLE
Fix compilation with glog >= 0.7.0

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -50,6 +50,15 @@ find_package(urdf REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
+# glog is not linked, however we look for it to detect the glog version
+# and use a different code path if glog >= 0.7.0 is detected
+find_package(glog CONFIG QUIET)
+if(DEFINED glog_VERSION)
+  if(NOT glog_VERSION VERSION_LESS 0.7.0)
+    add_definitions(-DROS_CARTOGRAPHER_GLOG_GE_070)
+  endif()
+endif()
+
 include_directories(
   include
   ${PCL_INCLUDE_DIRS}

--- a/cartographer_ros/src/ros_log_sink.cpp
+++ b/cartographer_ros/src/ros_log_sink.cpp
@@ -33,10 +33,12 @@ const char* GetBasename(const char* filepath) {
   return base ? (base + 1) : filepath;
 }
 
+#if defined(ROS_CARTOGRAPHER_GLOG_GE_070)
 std::chrono::system_clock::time_point ConvertTmToTimePoint(const std::tm& tm) {
     std::time_t timeT = std::mktime(const_cast<std::tm*>(&tm)); // Convert std::tm to time_t
     return std::chrono::system_clock::from_time_t(timeT);      // Convert time_t to time_point
 }
+#endif
 
 }  // namespace
 


### PR DESCRIPTION
This PR address the compilation failure if glog >= 0.7.0 is used, reported in https://github.com/cartographer-project/cartographer_ros/issues/1741 .