### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -102,37 +102,31 @@ set(dependencies
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
   ${dependencies}
+  cartographer
+  ${PCL_LIBRARIES}
 )
-target_link_libraries(${PROJECT_NAME} cartographer ${PCL_LIBRARIES})
 
 # Executables
 add_executable(cartographer_node src/node_main.cpp)
-target_link_libraries(cartographer_node ${PROJECT_NAME})
-target_link_libraries(cartographer_node PUBLIC ${dependencies})
+target_link_libraries(cartographer_node ${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(cartographer_occupancy_grid_node src/occupancy_grid_node_main.cpp)
-target_link_libraries(cartographer_occupancy_grid_node ${PROJECT_NAME})
-target_link_libraries(cartographer_occupancy_grid_node PUBLIC ${dependencies})
+target_link_libraries(cartographer_occupancy_grid_node ${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(cartographer_offline_node src/offline_node_main.cpp)
-target_link_libraries(cartographer_offline_node ${PROJECT_NAME})
-target_link_libraries(cartographer_offline_node PUBLIC ${dependencies})
+target_link_libraries(cartographer_offline_node ${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(cartographer_assets_writer src/assets_writer_main.cpp)
-target_link_libraries(cartographer_assets_writer ${PROJECT_NAME})
-target_link_libraries(cartographer_assets_writer PUBLIC ${dependencies})
+target_link_libraries(cartographer_assets_writer ${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(cartographer_pbstream_map_publisher src/pbstream_map_publisher_main.cpp)
-target_link_libraries(cartographer_pbstream_map_publisher ${PROJECT_NAME})
-target_link_libraries(cartographer_pbstream_map_publisher PUBLIC ${dependencies})
+target_link_libraries(cartographer_pbstream_map_publisher ${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(cartographer_pbstream_to_ros_map src/pbstream_to_ros_map_main.cpp)
-target_link_libraries(cartographer_pbstream_to_ros_map ${PROJECT_NAME})
-target_link_libraries(cartographer_pbstream_to_ros_map PUBLIC ${dependencies})
+target_link_libraries(cartographer_pbstream_to_ros_map ${PROJECT_NAME} PUBLIC ${dependencies})
 
 add_executable(cartographer_rosbag_validate src/rosbag_validate_main.cpp)
-target_link_libraries(cartographer_rosbag_validate ${PROJECT_NAME})
-target_link_libraries(cartographer_rosbag_validate PUBLIC ${dependencies})
+target_link_libraries(cartographer_rosbag_validate ${PROJECT_NAME} PUBLIC ${dependencies})
 
 if($ENV{ROS_DISTRO} MATCHES "humble" OR $ENV{ROS_DISTRO} MATCHES "iron")
   target_compile_definitions(${PROJECT_NAME} PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -100,39 +100,39 @@ set(dependencies
   urdf
   urdfdom
 )
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   ${dependencies}
-  )
+)
 target_link_libraries(${PROJECT_NAME} cartographer ${PCL_LIBRARIES})
 
 # Executables
 add_executable(cartographer_node src/node_main.cpp)
 target_link_libraries(cartographer_node ${PROJECT_NAME})
-ament_target_dependencies(cartographer_node ${dependencies})
+target_link_libraries(cartographer_node PUBLIC ${dependencies})
 
 add_executable(cartographer_occupancy_grid_node src/occupancy_grid_node_main.cpp)
 target_link_libraries(cartographer_occupancy_grid_node ${PROJECT_NAME})
-ament_target_dependencies(cartographer_occupancy_grid_node ${dependencies})
+target_link_libraries(cartographer_occupancy_grid_node PUBLIC ${dependencies})
 
 add_executable(cartographer_offline_node src/offline_node_main.cpp)
 target_link_libraries(cartographer_offline_node ${PROJECT_NAME})
-ament_target_dependencies(cartographer_offline_node ${dependencies})
+target_link_libraries(cartographer_offline_node PUBLIC ${dependencies})
 
 add_executable(cartographer_assets_writer src/assets_writer_main.cpp)
 target_link_libraries(cartographer_assets_writer ${PROJECT_NAME})
-ament_target_dependencies(cartographer_assets_writer ${dependencies})
+target_link_libraries(cartographer_assets_writer PUBLIC ${dependencies})
 
 add_executable(cartographer_pbstream_map_publisher src/pbstream_map_publisher_main.cpp)
 target_link_libraries(cartographer_pbstream_map_publisher ${PROJECT_NAME})
-ament_target_dependencies(cartographer_pbstream_map_publisher ${dependencies})
+target_link_libraries(cartographer_pbstream_map_publisher PUBLIC ${dependencies})
 
 add_executable(cartographer_pbstream_to_ros_map src/pbstream_to_ros_map_main.cpp)
 target_link_libraries(cartographer_pbstream_to_ros_map ${PROJECT_NAME})
-ament_target_dependencies(cartographer_pbstream_to_ros_map ${dependencies})
+target_link_libraries(cartographer_pbstream_to_ros_map PUBLIC ${dependencies})
 
 add_executable(cartographer_rosbag_validate src/rosbag_validate_main.cpp)
 target_link_libraries(cartographer_rosbag_validate ${PROJECT_NAME})
-ament_target_dependencies(cartographer_rosbag_validate ${dependencies})
+target_link_libraries(cartographer_rosbag_validate PUBLIC ${dependencies})
 
 if($ENV{ROS_DISTRO} MATCHES "humble" OR $ENV{ROS_DISTRO} MATCHES "iron")
   target_compile_definitions(${PROJECT_NAME} PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -100,33 +100,51 @@ set(dependencies
   urdf
   urdfdom
 )
+set(dependency_targets
+  ${builtin_interfaces_TARGETS}
+  ${cartographer_ros_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${tf2_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
+  sensor_msgs::sensor_msgs_library
+  tf2::tf2
+  tf2_eigen::tf2_eigen
+  tf2_ros::tf2_ros
+  urdf::urdf
+)
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${dependencies}
+  ${dependency_targets}
   cartographer
   ${PCL_LIBRARIES}
 )
 
 # Executables
 add_executable(cartographer_node src/node_main.cpp)
-target_link_libraries(cartographer_node ${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(cartographer_node ${PROJECT_NAME} ${dependency_targets})
 
 add_executable(cartographer_occupancy_grid_node src/occupancy_grid_node_main.cpp)
-target_link_libraries(cartographer_occupancy_grid_node ${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(cartographer_occupancy_grid_node ${PROJECT_NAME} ${dependency_targets})
 
 add_executable(cartographer_offline_node src/offline_node_main.cpp)
-target_link_libraries(cartographer_offline_node ${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(cartographer_offline_node ${PROJECT_NAME} ${dependency_targets})
 
 add_executable(cartographer_assets_writer src/assets_writer_main.cpp)
-target_link_libraries(cartographer_assets_writer ${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(cartographer_assets_writer ${PROJECT_NAME} ${dependency_targets})
 
 add_executable(cartographer_pbstream_map_publisher src/pbstream_map_publisher_main.cpp)
-target_link_libraries(cartographer_pbstream_map_publisher ${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(cartographer_pbstream_map_publisher ${PROJECT_NAME} ${dependency_targets})
 
 add_executable(cartographer_pbstream_to_ros_map src/pbstream_to_ros_map_main.cpp)
-target_link_libraries(cartographer_pbstream_to_ros_map ${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(cartographer_pbstream_to_ros_map ${PROJECT_NAME} ${dependency_targets})
 
 add_executable(cartographer_rosbag_validate src/rosbag_validate_main.cpp)
-target_link_libraries(cartographer_rosbag_validate ${PROJECT_NAME} PUBLIC ${dependencies})
+target_link_libraries(cartographer_rosbag_validate ${PROJECT_NAME} ${dependency_targets})
 
 if($ENV{ROS_DISTRO} MATCHES "humble" OR $ENV{ROS_DISTRO} MATCHES "iron")
   target_compile_definitions(${PROJECT_NAME} PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -77,10 +77,6 @@ set(dependencies
   rviz_rendering
   )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${dependencies}
-)
-
 target_include_directories(${PROJECT_NAME} PUBLIC
   ${OGRE_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
@@ -92,6 +88,8 @@ target_link_libraries(${PROJECT_NAME}
   ${EIGEN3_LIBRARIES}
   ${Boost_LIBRARIES}
   rviz_common::rviz_common
+  PUBLIC
+  ${dependencies}
   )
 
 

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -77,6 +77,14 @@ set(dependencies
   rviz_rendering
   )
 
+set(dependency_targets
+  ${cartographer_ros_msgs_TARGETS}
+  rclcpp::rclcpp
+  rviz_common::rviz_common
+  rviz_ogre_vendor::OgreMain
+  rviz_rendering::rviz_rendering
+)
+
 target_include_directories(${PROJECT_NAME} PUBLIC
   ${OGRE_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
@@ -88,8 +96,7 @@ target_link_libraries(${PROJECT_NAME}
   ${EIGEN3_LIBRARIES}
   ${Boost_LIBRARIES}
   rviz_common::rviz_common
-  PUBLIC
-  ${dependencies}
+  ${dependency_targets}
   )
 
 

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -77,7 +77,7 @@ set(dependencies
   rviz_rendering
   )
 
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   ${dependencies}
 )
 


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
