### PR TITLE
Heavily cleanup the cartographer_ros cmake

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -28,14 +28,16 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+find_package(absl REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(cartographer REQUIRED)
 find_package(cartographer_ros_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(absl REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common)
+find_package(gflags REQUIRED)
+find_package(glog REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
@@ -47,7 +49,6 @@ find_package(tf2_eigen REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(urdf REQUIRED)
-find_package(urdfdom_headers REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 # glog is not linked, however we look for it to detect the glog version
@@ -59,14 +60,11 @@ if(DEFINED glog_VERSION)
   endif()
 endif()
 
-include_directories(
-  include
-  ${PCL_INCLUDE_DIRS}
-  ${urdfdom_headers_INCLUDE_DIRS}
-)
+include(FindPkgConfig)
+pkg_search_module(CAIRO REQUIRED cairo>=1.12.16)
 
 # Library
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/assets_writer.cpp
   src/map_builder_bridge.cpp
   src/msg_conversion.cpp
@@ -87,69 +85,166 @@ add_library(${PROJECT_NAME}
   src/metrics/family_factory.cpp
   src/metrics/internal/family.cpp
   src/metrics/internal/histogram.cpp
-  )
-
-set(dependencies
-  builtin_interfaces
-  cartographer
-  cartographer_ros_msgs
-  geometry_msgs
-  nav_msgs
-  pcl_conversions
-  rclcpp
-  sensor_msgs
-  std_msgs
-  tf2
-  tf2_eigen
-  tf2_msgs
-  tf2_ros
-  visualization_msgs
-  rosbag2_cpp
-  rosbag2_storage
-  urdf
-  urdfdom
 )
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies}
-  )
-target_link_libraries(${PROJECT_NAME} cartographer ${PCL_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  ${CAIRO_INCLUDE_DIRS}
+  ${pcl_conversions_INCLUDE_DIRS}
+)
+if ("$ENV{ROS_DISTRO}" STRLESS "kilted")
+  # In Kilted, pcl_conversions was converted over to an INTERFACE target,
+  # but prior to it it is only available as the INCLUDE_DIRS.  So we have this
+  # compatibility hack to deal with that difference.
+  target_include_directories(${PROJECT_NAME} PRIVATE ${pcl_conversions_INCLUDE_DIRS})
+else()
+  target_link_libraries(${PROJECT_NAME} PRIVATE pcl_conversions::pcl_conversions)
+endif()
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  absl::synchronization
+  ${builtin_interfaces_TARGETS}
+  cartographer
+  ${cartographer_ros_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
+  ${sensor_msgs_TARGETS}
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  ${CAIRO_LIBRARIES}
+  pcl_common
+  ${std_msgs_TARGETS}
+  tf2::tf2
+  tf2_eigen::tf2_eigen
+  ${tf2_msgs_TARGETS}
+  urdf::urdf
+)
 
 # Executables
 add_executable(cartographer_node src/node_main.cpp)
-target_link_libraries(cartographer_node ${PROJECT_NAME})
-ament_target_dependencies(cartographer_node ${dependencies})
+target_include_directories(cartographer_node PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(cartographer_node PRIVATE
+  ${PROJECT_NAME}
+  absl::memory
+  cartographer
+  gflags
+  rclcpp::rclcpp
+  tf2_ros::tf2_ros
+)
 
 add_executable(cartographer_occupancy_grid_node src/occupancy_grid_node_main.cpp)
-target_link_libraries(cartographer_occupancy_grid_node ${PROJECT_NAME})
-ament_target_dependencies(cartographer_occupancy_grid_node ${dependencies})
+target_include_directories(cartographer_occupancy_grid_node PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  ${CAIRO_INCLUDE_DIRS}
+)
+target_link_libraries(cartographer_occupancy_grid_node PRIVATE
+  ${PROJECT_NAME}
+  absl::synchronization
+  cartographer
+  ${cartographer_ros_msgs_TARGETS}
+  Eigen3::Eigen
+  gflags
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+)
 
 add_executable(cartographer_offline_node src/offline_node_main.cpp)
-target_link_libraries(cartographer_offline_node ${PROJECT_NAME})
-ament_target_dependencies(cartographer_offline_node ${dependencies})
+target_include_directories(cartographer_offline_node PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(cartographer_offline_node PRIVATE
+  ${PROJECT_NAME}
+  cartographer
+  gflags
+  rclcpp::rclcpp
+)
 
 add_executable(cartographer_assets_writer src/assets_writer_main.cpp)
-target_link_libraries(cartographer_assets_writer ${PROJECT_NAME})
-ament_target_dependencies(cartographer_assets_writer ${dependencies})
+target_include_directories(cartographer_assets_writer PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(cartographer_assets_writer PRIVATE
+  ${PROJECT_NAME}
+  gflags
+  glog::glog
+  rclcpp::rclcpp
+)
 
 add_executable(cartographer_pbstream_map_publisher src/pbstream_map_publisher_main.cpp)
-target_link_libraries(cartographer_pbstream_map_publisher ${PROJECT_NAME})
-ament_target_dependencies(cartographer_pbstream_map_publisher ${dependencies})
+target_include_directories(cartographer_pbstream_map_publisher PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(cartographer_pbstream_map_publisher PRIVATE
+  ${PROJECT_NAME}
+  cartographer
+  gflags
+  glog::glog
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+)
 
 add_executable(cartographer_pbstream_to_ros_map src/pbstream_to_ros_map_main.cpp)
-target_link_libraries(cartographer_pbstream_to_ros_map ${PROJECT_NAME})
-ament_target_dependencies(cartographer_pbstream_to_ros_map ${dependencies})
+target_include_directories(cartographer_pbstream_to_ros_map PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(cartographer_pbstream_to_ros_map PRIVATE
+  ${PROJECT_NAME}
+  cartographer
+  gflags
+  glog::glog
+  rclcpp::rclcpp
+)
 
 add_executable(cartographer_rosbag_validate src/rosbag_validate_main.cpp)
-target_link_libraries(cartographer_rosbag_validate ${PROJECT_NAME})
-ament_target_dependencies(cartographer_rosbag_validate ${dependencies})
+target_include_directories(cartographer_rosbag_validate PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(cartographer_rosbag_validate
+  ${PROJECT_NAME}
+  absl::memory
+  cartographer
+  gflags
+  glog::glog
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  ${sensor_msgs_TARGETS}
+  tf2_eigen::tf2_eigen
+  ${tf2_msgs_TARGETS}
+  tf2_ros::tf2_ros
+  urdf::urdf
+  tf2::tf2
+)
 
 if($ENV{ROS_DISTRO} MATCHES "humble" OR $ENV{ROS_DISTRO} MATCHES "iron")
   target_compile_definitions(${PROJECT_NAME} PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)
   target_compile_definitions(cartographer_rosbag_validate PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)
 endif()
 
-install(TARGETS
-  ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -167,16 +262,30 @@ install(TARGETS
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(DIRECTORY configuration_files urdf launch
   DESTINATION share/${PROJECT_NAME}/
 )
 
-ament_export_include_directories(include)
+ament_export_targets(${PROJECT_NAME})
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  absl
+  builtin_interfaces
+  cartographer
+  cartographer_ros_msgs
+  geometry_msgs
+  nav_msgs
+  rclcpp
+  rosbag2_cpp
+  rosbag2_storage
+  sensor_msgs
+  tf2_ros
+  visualization_msgs
+)
 ament_package()
 
 # Non converted bin:

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(nav_msgs REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(ros_environment REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -98,6 +99,9 @@ if ("$ENV{ROS_DISTRO}" STRLESS "kilted")
   # but prior to it it is only available as the INCLUDE_DIRS.  So we have this
   # compatibility hack to deal with that difference.
   target_include_directories(${PROJECT_NAME} PRIVATE ${pcl_conversions_INCLUDE_DIRS})
+  # In Kilted, urdf/model.h was deprecated in favor of urdf/model.hpp.
+  # Deal with the difference here so we have no warnings.
+  target_compile_definitions(${PROJECT_NAME} PRIVATE "-DUSE_URDF_H_FILES")
 else()
   target_link_libraries(${PROJECT_NAME} PRIVATE pcl_conversions::pcl_conversions)
 endif()
@@ -221,6 +225,9 @@ target_include_directories(cartographer_rosbag_validate PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
+if ("$ENV{ROS_DISTRO}" STRLESS "kilted")
+  target_compile_definitions(cartographer_rosbag_validate PRIVATE "-DUSE_URDF_H_FILES")
+endif()
 target_link_libraries(cartographer_rosbag_validate
   ${PROJECT_NAME}
   absl::memory

--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -81,6 +81,7 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>libabsl-dev</depend>
+  <depend>libcairo2-dev</depend>
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>libpcl-all-dev</depend>

--- a/cartographer_ros/src/assets_writer.cpp
+++ b/cartographer_ros/src/assets_writer.cpp
@@ -45,7 +45,11 @@
 #include "tf2_eigen/tf2_eigen.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
+#ifdef USE_URDF_H_FILES
 #include "urdf/model.h"
+#else
+#include "urdf/model.hpp"
+#endif
 
 namespace cartographer_ros {
 namespace {

--- a/cartographer_ros/src/assets_writer_main.cpp
+++ b/cartographer_ros/src/assets_writer_main.cpp
@@ -17,6 +17,7 @@
 #include "cartographer_ros/assets_writer.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+#include "rclcpp/rclcpp.hpp"
 #include <regex>
 #include <string>
 

--- a/cartographer_ros/src/node_main.cpp
+++ b/cartographer_ros/src/node_main.cpp
@@ -20,6 +20,7 @@
 #include "cartographer_ros/node_options.h"
 #include "cartographer_ros/ros_log_sink.h"
 #include "gflags/gflags.h"
+#include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/transform_listener.h"
 
 DEFINE_bool(collect_metrics, false,

--- a/cartographer_ros/src/offline_node.cpp
+++ b/cartographer_ros/src/offline_node.cpp
@@ -31,7 +31,11 @@
 #include "gflags/gflags.h"
 #include "rosgraph_msgs/msg/clock.hpp"
 #include "tf2_ros/static_transform_broadcaster.h"
+#ifdef USE_URDF_H_FILES
 #include "urdf/model.h"
+#else
+#include "urdf/model.hpp"
+#endif
 #include "rclcpp/exceptions.hpp"
 #include <regex>
 #include <string>

--- a/cartographer_ros/src/rosbag_validate_main.cpp
+++ b/cartographer_ros/src/rosbag_validate_main.cpp
@@ -36,7 +36,11 @@
 #include "tf2_eigen/tf2_eigen.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/buffer.h"
+#ifdef USE_URDF_H_FILES
 #include "urdf/model.h"
+#else
+#include "urdf/model.hpp"
+#endif
 #include <tf2/utils.hpp>
 
 DEFINE_string(bag_filename, "", "Bag to process.");

--- a/cartographer_ros/src/urdf_reader.cpp
+++ b/cartographer_ros/src/urdf_reader.cpp
@@ -20,7 +20,12 @@
 #include <vector>
 
 #include "cartographer_ros/msg_conversion.h"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#ifdef USE_URDF_H_FILES
 #include "urdf/model.h"
+#else
+#include "urdf/model.hpp"
+#endif
 
 namespace cartographer_ros {
 

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -35,10 +35,9 @@ set(BUILD_SHARED_LIBS OFF)
 option(BUILD_GRPC "build features that require Cartographer gRPC support" false)
 google_initialize_cartographer_project()
 
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(absl REQUIRED)
 find_package(cartographer_ros REQUIRED)
 find_package(cartographer_ros_msgs REQUIRED)
-find_package(absl REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -56,44 +55,29 @@ set(rviz_plugins_headers_to_moc
   include/cartographer_rviz/submaps_display.h
 )
 
-include_directories(
-  include
-  )
-
 add_library(${PROJECT_NAME} SHARED
   src/drawable_submap.cpp
   src/ogre_slice.cpp
   src/submaps_display.cpp
   ${rviz_plugins_headers_to_moc}
-  )
-
-set(dependencies
-  cartographer
-  cartographer_ros
-  cartographer_ros_msgs
-  rclcpp
-  rviz_common
-  rviz_ogre_vendor
-  rviz_rendering
-  )
-
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies}
 )
-
 target_include_directories(${PROJECT_NAME} PUBLIC
-  ${OGRE_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
-  ${Boost_INCLUDE_DIRS}
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
 )
-
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  absl::synchronization
   cartographer
-  ${EIGEN3_LIBRARIES}
-  ${Boost_LIBRARIES}
+  cartographer_ros::cartographer_ros
+  Eigen3::Eigen
+  rclcpp::rclcpp
   rviz_common::rviz_common
-  )
-
+  rviz_rendering::rviz_rendering
+  tf2_ros::tf2_ros
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  pluginlib::pluginlib
+)
 
 pluginlib_export_plugin_description_file(rviz_common rviz_plugin_description.xml)
 register_rviz_ogre_media_exports(DIRECTORIES "ogre_media/materials/glsl120" "ogre_media/materials/scripts")
@@ -104,18 +88,26 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION include/${PROJECT_NAME}
 )
 
 install(
   DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
-  ${dependencies}
+  absl
+  cartographer
+  cartographer_ros
+  eigen
+  rclcpp
+  rviz_common
+  rviz_rendering
+  tf2_ros
 )
 
 ament_package()

--- a/cartographer_rviz/package.xml
+++ b/cartographer_rviz/package.xml
@@ -76,7 +76,6 @@
   <depend>cartographer_ros_msgs</depend>
   <depend>eigen</depend>
   <depend>libabsl-dev</depend>
-  <depend>libboost-iostreams-dev</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rviz_common</depend>


### PR DESCRIPTION
The biggest goal here is to get rid of deprecation warnings.  To do that, we switch away from `ament_target_dependencies` and instead specify everything with regular CMake `target_link_libraries` (with a couple of backwards compatible exceptions).

With this in place, cartographer_ros and cartographer_rviz build without warnings on Rolling, Kilted, Jazzy, and Humble.