### PR TITLE
Fixes #80: Fix the error with the multi-definition of flag  'collect_metrics' 

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -65,7 +65,7 @@ include(FindPkgConfig)
 pkg_search_module(CAIRO REQUIRED cairo>=1.12.16)
 
 # Library
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME} STATIC
   src/assets_writer.cpp
   src/map_builder_bridge.cpp
   src/msg_conversion.cpp

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -44,6 +44,8 @@ find_package(rclcpp REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_rendering REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_eigen REQUIRED)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -74,6 +76,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   rviz_common::rviz_common
   rviz_rendering::rviz_rendering
   tf2_ros::tf2_ros
+  tf2_eigen::tf2_eigen
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE
   pluginlib::pluginlib

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -46,6 +46,7 @@ find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
+find_package(pcl_conversions REQUIRED)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -47,6 +47,8 @@ find_package(rviz_rendering REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(pcl_conversions REQUIRED)
+find_package(urdf REQUIRED)
+
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -78,6 +80,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   rviz_rendering::rviz_rendering
   tf2_ros::tf2_ros
   tf2_eigen::tf2_eigen
+  pcl_conversions::pcl_conversions
+  urdf::urdf
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE
   pluginlib::pluginlib

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -80,8 +80,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   rviz_rendering::rviz_rendering
   tf2_ros::tf2_ros
   tf2_eigen::tf2_eigen
-  pcl_conversions::pcl_conversions
-  urdf::urdf
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE
   pluginlib::pluginlib


### PR DESCRIPTION
Fix the error #80 , with the multi-definition of flag  'collect_metrics'  when compile cartographer_ros. I change the library of cmake from shared to static lib and this resolve the error.
[https://github.com/ros2/cartographer_ros/issues/80](url)