### PR TITLE
Fix duplicate symbol error for `collect_metrics` flag in offline_node (Issue #80)

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -72,7 +72,6 @@ add_library(${PROJECT_NAME} SHARED
   src/node_constants.cpp
   src/node.cpp
   src/node_options.cpp
-  src/offline_node.cpp
   src/playable_bag.cpp
   src/ros_log_sink.cpp
   src/ros_map.cpp
@@ -164,17 +163,24 @@ target_link_libraries(cartographer_occupancy_grid_node PRIVATE
   rclcpp::rclcpp
 )
 
-add_executable(cartographer_offline_node src/offline_node_main.cpp)
+add_executable(cartographer_offline_node
+  src/offline_node_main.cpp
+  src/offline_node.cpp
+)
 target_include_directories(cartographer_offline_node PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
+if ("$ENV{ROS_DISTRO}" STRLESS "kilted")
+  target_compile_definitions(cartographer_offline_node PRIVATE "-DUSE_URDF_H_FILES")
+endif()
 target_link_libraries(cartographer_offline_node PRIVATE
   ${PROJECT_NAME}
   cartographer
   gflags
   rclcpp::rclcpp
+  urdf::urdf
 )
 
 add_executable(cartographer_assets_writer src/assets_writer_main.cpp)
@@ -247,6 +253,7 @@ target_link_libraries(cartographer_rosbag_validate
 
 if($ENV{ROS_DISTRO} MATCHES "humble" OR $ENV{ROS_DISTRO} MATCHES "iron")
   target_compile_definitions(${PROJECT_NAME} PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)
+  target_compile_definitions(cartographer_offline_node PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)
   target_compile_definitions(cartographer_rosbag_validate PRIVATE PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME)
 endif()
 


### PR DESCRIPTION
## Description
This PR fixes a compilation issue caused by duplicate definition of the `collect_metrics` gflags flag.

### Issue
as issue #80 said, running `cartographer_ros` fails with the following error:
```
 [cartographer_node-2] ERROR: flag 'collect_metrics' was defined more than once (in files '/home/.../cartographer_ws/src/cartographer_ros/cartographer_ros/src/offline_node.cpp' and '/home/.../cartographer_ws/src/cartographer_ros/cartographer_ros/src/node_main.cpp').
```

This occurred because `src/offline_node.cpp` was being linked into both the `cartographer_ros` shared library and the `cartographer_offline_node` executable, causing a symbol conflict.

### Changes Made
1. Removed `src/offline_node.cpp` from the shared library source list to avoid duplicate symbol definitions.
2. Added `src/offline_node.cpp` to the `cartographer_offline_node` executable target.
3. Added missing `urdf` dependency to the offline node target.
4. Added macro definitions `PRE_JAZZY_SERIALIZED_BAG_MSG_FIELD_NAME` to maintain consistency.

### Verification
- All targets build successfully without new warnings.
- Verified in ROS Humble environments.